### PR TITLE
Fix `secret_key_base` returning `nil`

### DIFF
--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,11 +1,11 @@
 module JsonWebToken
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i
-    JWT.encode(payload, Rails.application.secrets.secret_key_base)
+    JWT.encode(payload, Rails.application.credentials.secret_key_base)
   end
 
   def self.decode(token)
-    body = JWT.decode(token, Rails.application.secrets.secret_key_base)[0]
+    body = JWT.decode(token, Rails.application.credentials.secret_key_base)[0]
     HashWithIndifferentAccess.new body
   rescue
     nil


### PR DESCRIPTION
In Rails 5.2, `Rails.application.secrets.secret_key_base` returns `nil`. This fixes it. Untested with < 5.2.