### PR TITLE
Fix a secret key from credentials for rails < 5.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 This is part of a tutorial article about authentication with JWT tokens in rails
-You can view the tutorial [here](http://tutorials.pluralsight.com/ruby-ruby-on-rails/token-based-authentication-with-ruby-on-rails-5-api)
+You can view the tutorial [here](https://www.pluralsight.com/guides/token-based-authentication-with-ruby-on-rails-5-api)
 
 ## Setup
 

--- a/lib/json_web_token.rb
+++ b/lib/json_web_token.rb
@@ -1,13 +1,19 @@
 module JsonWebToken
   def self.encode(payload, exp = 24.hours.from_now)
     payload[:exp] = exp.to_i
-    JWT.encode(payload, Rails.application.credentials.secret_key_base)
+    JWT.encode(payload, secret_key)
   end
 
   def self.decode(token)
-    body = JWT.decode(token, Rails.application.credentials.secret_key_base)[0]
+    body = JWT.decode(token, secret_key)[0]
     HashWithIndifferentAccess.new body
   rescue
     nil
+  end
+
+  private
+
+  def secret_key
+    Rails.application.secrets&.secret_key_base || Rails.application.credentials&.secret_key_base
   end
 end


### PR DESCRIPTION
https://github.com/hggeorgiev/rails-jwt-auth-tutorial/issues/8
It happened because in https://github.com/hggeorgiev/rails-jwt-auth-tutorial/commit/8042abc0261b55ae83b3d43c196babe84c750df0 author changed secrets to credentials, but in rails < 5.2.0 this method are undefined.